### PR TITLE
Use `cabal-version: 3.8`

### DIFF
--- a/cabal-doctest-demo.cabal
+++ b/cabal-doctest-demo.cabal
@@ -1,4 +1,4 @@
-cabal-version:      3.6
+cabal-version:      3.8
 name:               cabal-doctest-demo
 version:            0.1.0.0
 synopsis:


### PR DESCRIPTION
This is the first `cabal` version to support `code-generators`.